### PR TITLE
Add instructions about node-xmpp-client parameters

### DIFF
--- a/_posts/2014-03-15-nodexmppclient.md
+++ b/_posts/2014-03-15-nodexmppclient.md
@@ -37,6 +37,7 @@ var client = new Client(...parameters...)
 * __oauth2_auth__ [String]: OAuth2 namespace e.g. used for logging into google talk
 * __api_key__ [String]: For logging into Facebook XMPP account
 * __access_token__ [String]: For logging into Facebook XMPP account
+* __wait__ [String]: The HTTPBIND wait value. This is the time the server will wait before returning an empty result for a request. Default is 10 seconds.
 
 # Basic Example
 


### PR DESCRIPTION
Add the instructions about the new custom "wait" parameters for Bosh connections.
